### PR TITLE
Change Twig loader to save template duplication

### DIFF
--- a/src/app.php
+++ b/src/app.php
@@ -7,7 +7,10 @@ require_once __DIR__.'/../vendor/Silex/silex.phar';
 $app = new Silex\Application;
 
 $app->register(new \Silex\Extension\TwigExtension(), array(
-    'twig.path' => __DIR__.'/templates',
+    'twig.path' => array(
+        __DIR__.'/templates',
+        __DIR__ . '/../vendor/symfony/src/Symfony/Bridge/Twig/Resources/views/Form'
+    ),
     'twig.class_path' => __DIR__.'/../vendor/Twig/lib',
 ));
 


### PR DESCRIPTION
Thanks to @Stof, I discovered that the loader can take an array of locations. This means you can delete the form layout you have in templates too.
